### PR TITLE
Security fixes

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -522,7 +522,10 @@ class Settings {
 	 * Register post meta for disabling plugin per
 	 */
 	public function register_post_meta() {
-		if ( is_array( $this->disable_option_object_types ) ) {
+		if ( ! is_array( $this->disable_option_object_types ) ) {
+			return;
+		}
+
 			foreach ( $this->disable_option_object_types as $object_type ) {
 				\register_post_meta(
 					$object_type,
@@ -536,7 +539,6 @@ class Settings {
 				);
 			}
 		}
-	}
 
 	/**
 	 * Add checkbox to Publish Post meta box.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -129,6 +129,18 @@ class Settings {
 	public $lazysizes_config = '';
 
 	/**
+	 * Allowed HTML tags in descriptions.
+	 *
+	 * @var array
+	 */
+	private $allowed_description_html = array(
+			'a' => array( 'href' => array() ),
+			'br' => array(),
+			'code' => array(),
+			'strong' => array(),
+	);
+
+	/**
 	 * Settings constructor.
 	 */
 	public function __construct() {
@@ -369,7 +381,7 @@ class Settings {
 		// Check for description.
 		if ( '' !== $args['description'] ) { ?>
 			<p class="description">
-				<?php echo $args['description']; ?>
+				<?php echo wp_kses( $args['description'], $this->allowed_description_html  ); ?>
 			</p>
 			<?php
 		}
@@ -398,7 +410,7 @@ class Settings {
 		// Check for description.
 		if ( '' !== $args['description'] ) { ?>
 			<p class="description">
-				<?php echo $args['description']; ?>
+				<?php echo wp_kses( $args['description'], $this->allowed_description_html  ); ?>
 			</p>
 			<?php
 		}
@@ -425,7 +437,7 @@ class Settings {
 		// Check for description.
 		if ( '' !== $args['description'] ) { ?>
 			<p class="description">
-				<?php echo $args['description']; ?>
+				<?php echo wp_kses( $args['description'], $this->allowed_description_html  ); ?>
 			</p>
 			<?php
 		}
@@ -457,7 +469,7 @@ class Settings {
 		// Check for description.
 		if ( '' !== $args['description'] ) { ?>
 			<p class="description">
-				<?php echo $args['description']; ?>
+				<?php echo wp_kses( $args['description'], array( 'a', 'strong', 'code', 'br' ) ); ?>
 			</p>
 			<?php
 		}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -405,7 +405,7 @@ class Settings {
 		// Get label for.
 		?>
 		<input id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( $args['label_for'] ); ?>"
-			   type="text" value="<?php echo $option_value; ?>">
+			   type="text" value="<?php echo esc_attr( $option_value ); ?>">
 		<?php
 		// Check for description.
 		if ( '' !== $args['description'] ) { ?>
@@ -432,7 +432,7 @@ class Settings {
 		$option_value = $args['value'];
 
 		?>
-		<textarea id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( $args['label_for'] ); ?>" style="width: 100%;"><?php echo $option_value; ?></textarea>
+		<textarea id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( $args['label_for'] ); ?>" style="width: 100%;"><?php echo esc_textarea( $option_value ); ?></textarea>
 		<?php
 		// Check for description.
 		if ( '' !== $args['description'] ) { ?>
@@ -462,8 +462,8 @@ class Settings {
 		// Get label for.
 		?>
 		<input id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( $args['label_for'] ); ?>"
-			   type="text" value="<?php echo $option_value; ?>"
-			   data-default-color="<?php echo self::$loading_spinner_color_default; ?>"
+			   type="text" value="<?php echo esc_attr( $option_value ); ?>"
+			   data-default-color="<?php echo esc_attr( self::$loading_spinner_color_default ); ?>"
 			   class="lazy-load-responsive-images-color-field">
 		<?php
 		// Check for description.
@@ -563,7 +563,7 @@ class Settings {
 			</div>',
 			$maybe_enabled ? '' : 'disabled',
 			$value === 1 ? 'checked' : '',
-			__( 'Disable Lazy Loader', 'lazy-loading-responsive-images' )
+			esc_html__( 'Disable Lazy Loader', 'lazy-loading-responsive-images' )
 		);
 	}
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -116,14 +116,14 @@ class Settings {
 
 	/**
 	 * Array of object types that should show the checkbox to disable lazy loading.
-	 * 
+	 *
 	 * @var array
 	 */
 	public $disable_option_object_types = array();
 
 	/**
 	 * String to modify lazysizes config.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $lazysizes_config = '';
@@ -362,9 +362,9 @@ class Settings {
 		$option_value = $args['value'];
 
 		// Get label for.
-		$label_for = esc_attr( $args['label_for'] ); ?>
-		<input id="<?php echo $label_for; ?>" name="<?php echo $label_for; ?>"
-		       type="checkbox" <?php echo ( $option_value == '1' || $option_value == 'on' ) ? 'checked="checked"' : ''; ?>>
+		?>
+		<input id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( $args['label_for'] ); ?>"
+			   type="checkbox" <?php echo ( $option_value == '1' || $option_value == 'on' ) ? 'checked="checked"' : ''; ?>>
 		<?php
 		// Check for description.
 		if ( '' !== $args['description'] ) { ?>
@@ -391,9 +391,9 @@ class Settings {
 		$option_value = $args['value'];
 
 		// Get label for.
-		$label_for = esc_attr( $args['label_for'] ); ?>
-		<input id="<?php echo $label_for; ?>" name="<?php echo $label_for; ?>"
-		       type="text" value="<?php echo $option_value; ?>">
+		?>
+		<input id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( $args['label_for'] ); ?>"
+			   type="text" value="<?php echo $option_value; ?>">
 		<?php
 		// Check for description.
 		if ( '' !== $args['description'] ) { ?>
@@ -419,9 +419,8 @@ class Settings {
 		// Get option value.
 		$option_value = $args['value'];
 
-		// Get label for.
-		$label_for = esc_attr( $args['label_for'] ); ?>
-		<textarea id="<?php echo $label_for; ?>" name="<?php echo $label_for; ?>" style="width: 100%;"><?php echo $option_value; ?></textarea>
+		?>
+		<textarea id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( $args['label_for'] ); ?>" style="width: 100%;"><?php echo $option_value; ?></textarea>
 		<?php
 		// Check for description.
 		if ( '' !== $args['description'] ) { ?>
@@ -449,11 +448,11 @@ class Settings {
 		$option_value = $args['value'];
 
 		// Get label for.
-		$label_for = esc_attr( $args['label_for'] ); ?>
-		<input id="<?php echo $label_for; ?>" name="<?php echo $label_for; ?>"
-		       type="text" value="<?php echo $option_value; ?>"
-		       data-default-color="<?php echo self::$loading_spinner_color_default; ?>"
-		       class="lazy-load-responsive-images-color-field">
+		?>
+		<input id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( $args['label_for'] ); ?>"
+			   type="text" value="<?php echo $option_value; ?>"
+			   data-default-color="<?php echo self::$loading_spinner_color_default; ?>"
+			   class="lazy-load-responsive-images-color-field">
 		<?php
 		// Check for description.
 		if ( '' !== $args['description'] ) { ?>
@@ -500,7 +499,7 @@ class Settings {
 		 * Filter for the object types that should show the checkbox
 		 * for disabling the lazy loading functionality. By default, all
 		 * public post types (except attachment) are included.
-		 * 
+		 *
 		 * @param array $public_post_types An array of post types that should have the option
 		 *                                 for disabling.
 		 */


### PR DESCRIPTION
- Late escapes: This has nothing to do with security but it doesn't give us a false positive while 
linting the code. Also, escaping late is a good practice.
- Escape several attributes and inputs/textarea values.
- Use `kses` to restrict what HTML tags are allowed in field descriptions.
- Simplify `register_post_meta` method in Settings.php